### PR TITLE
Handle missing claude-flow gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .venv/
 package.json
+__pycache__/

--- a/brain.md
+++ b/brain.md
@@ -21,3 +21,5 @@
 - parser_builder.py
 - run_flo.py now imports these.
 - Added .gitignore for untracked files.
+\n### 2025-07-27 Debugging\n- Modified SetupManager.setup_environment to set npm_config_yes and timeout to avoid interactive npx hang.\n- Updated .gitignore to exclude __pycache__.\n
+- Added timeout and npm_config_yes handling in CLI _run to prevent hang when npx prompts.

--- a/claude_flow_cli.py
+++ b/claude_flow_cli.py
@@ -21,11 +21,11 @@ class ClaudeFlowCLI:
         """
         cmd = ["npx", "claude-flow@alpha"] + args
         print(f"Ausführen: {' '.join(cmd)}")
-        # Übergibt die aktuellen Umgebungsvariablen an den Subprozess
         env = os.environ.copy()
+        env.setdefault("npm_config_yes", "true")
         try:
             # Führe den Befehl aus und speichere die Argumentliste in der Historie
-            subprocess.run(cmd, cwd=self.working_dir, env=env)
+            subprocess.run(cmd, cwd=self.working_dir, env=env, timeout=15)
             try:
                 # Speichere nur das Argumentsegment (ohne npx) für die Anzeige
                 self.command_history.append(' '.join(args))
@@ -44,8 +44,16 @@ class ClaudeFlowCLI:
         """
         cmd = ["npx", "claude-flow@alpha"] + args
         env = os.environ.copy()
+        env.setdefault("npm_config_yes", "true")
         try:
-            result = subprocess.run(cmd, cwd=self.working_dir, env=env, capture_output=True, text=True)
+            result = subprocess.run(
+                cmd,
+                cwd=self.working_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
             # Füge das Kommando zur Historie hinzu
             try:
                 self.command_history.append(' '.join(args))

--- a/setup_manager.py
+++ b/setup_manager.py
@@ -53,10 +53,21 @@ class SetupManager:
             cls.install_claude_code()
 
         try:
-            subprocess.run(["npx", "claude-flow@alpha", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            env = os.environ.copy()
+            env.setdefault("npm_config_yes", "true")
+            subprocess.run(
+                ["npx", "claude-flow@alpha", "--version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                timeout=15,
+            )
             print("[Setup] claude-flow@alpha ist bereits installiert.")
-        except Exception:
-            cls.install_claude_flow()
+        except Exception as e:
+            print(
+                f"[Setup] Warnung: 'claude-flow@alpha' konnte nicht verifiziert werden: {e}."
+            )
 
         if not cls._command_exists("claude"):
             print(
@@ -64,7 +75,14 @@ class SetupManager:
                 " Bitte stellen Sie sicher, dass @anthropic-ai/claude-code korrekt installiert ist."
             )
         try:
-            subprocess.run(["npx", "claude-flow@alpha", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(
+                ["npx", "claude-flow@alpha", "--version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                timeout=15,
+            )
         except Exception:
             print(
                 "[Setup] Warnung: 'claude-flow@alpha' konnte trotz Installation nicht gefunden werden."


### PR DESCRIPTION
## Summary
- avoid interactive `npx` checks in SetupManager by setting `npm_config_yes` and a timeout
- remove automatic install attempts for claude-flow when the check fails
- ensure CLI commands also set the environment flag and timeout to prevent hangs
- ignore `__pycache__` in git
- record debugging notes

## Testing
- `python3 run_flo.py -h`
- `python3 run_flo.py sparc-modes`

------
https://chatgpt.com/codex/tasks/task_e_68861f11761c832e8890a137e005165e