### PR TITLE
Fix setup verification and handle OpenRouter timeout

### DIFF
--- a/brain.md
+++ b/brain.md
@@ -23,3 +23,8 @@
 - Added .gitignore for untracked files.
 \n### 2025-07-27 Debugging\n- Modified SetupManager.setup_environment to set npm_config_yes and timeout to avoid interactive npx hang.\n- Updated .gitignore to exclude __pycache__.\n
 - Added timeout and npm_config_yes handling in CLI _run to prevent hang when npx prompts.
+\n### 2025-07-27 Further fixes
+- SetupManager.skip verifying claude-flow with npx to avoid lengthy install
+  checks; now only check if command exists.
+- OpenRouterClient timeout reduced to 5s and handles RequestException for
+  better failure handling in restricted environments.

--- a/setup_manager.py
+++ b/setup_manager.py
@@ -52,21 +52,16 @@ class SetupManager:
         else:
             cls.install_claude_code()
 
-        try:
-            env = os.environ.copy()
-            env.setdefault("npm_config_yes", "true")
-            subprocess.run(
-                ["npx", "claude-flow@alpha", "--version"],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-                timeout=15,
-            )
-            print("[Setup] claude-flow@alpha ist bereits installiert.")
-        except Exception as e:
+        # Vermeide potenziell lange Netzwerkaufrufe durch npx. Stattdessen
+        # wird lediglich geprüft, ob das Kommando ``claude-flow`` bereits im
+        # PATH vorhanden ist. Damit startet die Anwendung auch in Umgebungen
+        # ohne npm oder ohne Internetzugang schnell.
+        if cls._command_exists("claude-flow"):
+            print("[Setup] claude-flow ist vorhanden.")
+        else:
             print(
-                f"[Setup] Warnung: 'claude-flow@alpha' konnte nicht verifiziert werden: {e}."
+                "[Setup] Warnung: 'claude-flow' scheint nicht installiert zu sein."
+                " Einige Funktionen stehen möglicherweise nicht zur Verfügung."
             )
 
         if not cls._command_exists("claude"):
@@ -74,20 +69,7 @@ class SetupManager:
                 "[Setup] Warnung: Das Kommando 'claude' ist nach der Installation nicht auffindbar."
                 " Bitte stellen Sie sicher, dass @anthropic-ai/claude-code korrekt installiert ist."
             )
-        try:
-            subprocess.run(
-                ["npx", "claude-flow@alpha", "--version"],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-                timeout=15,
-            )
-        except Exception:
-            print(
-                "[Setup] Warnung: 'claude-flow@alpha' konnte trotz Installation nicht gefunden werden."
-                " Prüfen Sie die Installation und Ihre PATH-Variable."
-            )
+        # Keine weitere Verifikation per ``npx`` um Wartezeiten zu vermeiden.
         cls.load_env_tokens()
 
     @classmethod


### PR DESCRIPTION
## Summary
- avoid `npx` call in `SetupManager.setup_environment` to prevent network install attempts
- shorten OpenRouter request timeout and handle RequestException errors
- update brain notes with debugging steps

## Testing
- `python3 -m py_compile run_flo.py claude_flow_cli.py menu.py openrouter_client.py project_manager.py parser_builder.py setup_manager.py`
- `python3 run_flo.py -h`
- `python3 run_flo.py memory-stats` *(fails: ENOTEMPTY)*

------
https://chatgpt.com/codex/tasks/task_e_6886289bc914832eaf4a7e3818b21662