### PR TITLE
Fix CLI startup

### DIFF
--- a/brain.md
+++ b/brain.md
@@ -28,3 +28,8 @@
   checks; now only check if command exists.
 - OpenRouterClient timeout reduced to 5s and handles RequestException for
   better failure handling in restricted environments.
+
+### 2025-07-27 Argument parser fix
+- Removed required=True from parser subcommands.
+- Added check in run_flo.main to print help when no command provided.
+- Now running "python3 run_flo.py" shows help instead of error.

--- a/parser_builder.py
+++ b/parser_builder.py
@@ -5,7 +5,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Python‑Wrapper für Claude‑Flow v2.0.0 Alpha. Voraussetzung: npx claude-flow@alpha ist installiert."
     )
-    sub = parser.add_subparsers(dest="command", required=True)
+    sub = parser.add_subparsers(dest="command")
 
     # init
     init_p = sub.add_parser("init", help="Initialisiert ein neues Claude‑Flow‑Projekt")

--- a/run_flo.py
+++ b/run_flo.py
@@ -14,7 +14,12 @@ from parser_builder import build_parser
 def main(argv: Optional[List[str]] = None) -> None:
     SetupManager.setup_environment()
     parser = build_parser()
+
     args = parser.parse_args(argv)
+    if not args.command:
+        parser.print_help()
+        return
+
     cli = ClaudeFlowCLI(Path.cwd())
 
     cmd = args.command


### PR DESCRIPTION
## Summary
- allow `run_flo.py` without a command by making subparser optional
- show help if no command is passed
- note fix in `brain.md`

## Testing
- `python3 run_flo.py`


------
https://chatgpt.com/codex/tasks/task_e_68862d936884832ebd16f0cb82bf5117