### PR TITLE
Enhance TUI with prompt_toolkit dialog menu

### DIFF
--- a/brain.md
+++ b/brain.md
@@ -41,3 +41,4 @@
 - Added header and ESC key for quitting.
 - Integrated ProjectManagerMenu via "Advanced" menu using run_in_terminal.
 - Added basic status bar.
+\n### 2025-07-27 More TUI updates\n- Implemented ProjectManagerTUI using prompt_toolkit dialogs.\n- launch_manager_menu now opens this dialog instead of the old CLI menu.\n


### PR DESCRIPTION
## Summary
- add `ProjectManagerTUI` class with basic dialog-driven menu
- open this menu from `FloTUI` instead of dropping to the CLI
- update brain notes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `curl` GitHub issue creation (fails: Bad credentials)

------
https://chatgpt.com/codex/tasks/task_e_68863fa6c2e4832eac5c068db0d34c99