### PR TITLE
Implement nested menus in TUI

### DIFF
--- a/brain.md
+++ b/brain.md
@@ -43,3 +43,8 @@
 - Added basic status bar.
 \n### 2025-07-27 More TUI updates\n- Implemented ProjectManagerTUI using prompt_toolkit dialogs.\n- launch_manager_menu now opens this dialog instead of the old CLI menu.\n
 \n### 2025-07-27 TUI layout update\n- Replaced menubar with vertical RadioList menu.\n- Added Frame and Box layout with header, menu pane, output pane, and status bar.\n- ESC or Ctrl+C quits, Enter selects menu item.\n- run_flo.py compiles and CLI fallback unaffected.\n
+### 2025-07-27 Structured TUI menus
+- Replaced main menu options with categories Projects, Hive, Advanced, Exit.
+- Added projects_menu and hive_menu subdialogs using radiolist_dialog.
+- Each action triggers create/list/monitor or spawn/status/sessions.
+- Updated brain.md with new section.

--- a/run_flo.py
+++ b/run_flo.py
@@ -98,12 +98,9 @@ class FloTUI:
 
         self.menu = RadioList(
             [
-                ("create", "Create project"),
-                ("list", "List projects"),
-                ("spawn", "Hive spawn"),
-                ("status", "Hive status"),
-                ("sessions", "Hive sessions"),
-                ("advanced", "Advanced menu"),
+                ("projects", "Projects"),
+                ("hive", "Hive"),
+                ("advanced", "Advanced"),
                 ("exit", "Exit"),
             ]
         )
@@ -146,16 +143,10 @@ class FloTUI:
         self.app.invalidate()
 
     def handle_choice(self, choice: str | None) -> None:
-        if choice == "create":
-            self.create_project()
-        elif choice == "list":
-            self.list_projects()
-        elif choice == "spawn":
-            self.spawn_hive()
-        elif choice == "status":
-            self.hive_status()
-        elif choice == "sessions":
-            self.hive_sessions()
+        if choice == "projects":
+            self.projects_menu()
+        elif choice == "hive":
+            self.hive_menu()
         elif choice == "advanced":
             self.launch_manager_menu()
         else:
@@ -191,6 +182,53 @@ class FloTUI:
     def hive_sessions(self) -> None:
         self._info("Listing sessions ...")
         self._run_task(self.cli.hive_sessions)
+
+    # ------------------------------------------------------------------
+    # Sub menus
+    def projects_menu(self) -> None:
+        while True:
+            choice = radiolist_dialog(
+                title="Projects",
+                text="Choose an action",
+                values=[
+                    ("create", "Create project"),
+                    ("list", "List projects"),
+                    ("monitor", "Monitor & heal"),
+                    ("back", "Back"),
+                ],
+            ).run()
+            if choice == "create":
+                self.create_project()
+            elif choice == "list":
+                self.list_projects()
+            elif choice == "monitor":
+                session = input_dialog(title="Monitor", text="Session ID:").run()
+                if session:
+                    self._info("Monitoring ...")
+                    self._run_task(self.pm.monitor_and_self_heal, session)
+            else:
+                break
+
+    def hive_menu(self) -> None:
+        while True:
+            choice = radiolist_dialog(
+                title="Hive",
+                text="Choose an action",
+                values=[
+                    ("spawn", "Spawn hive"),
+                    ("status", "Hive status"),
+                    ("sessions", "Hive sessions"),
+                    ("back", "Back"),
+                ],
+            ).run()
+            if choice == "spawn":
+                self.spawn_hive()
+            elif choice == "status":
+                self.hive_status()
+            elif choice == "sessions":
+                self.hive_sessions()
+            else:
+                break
 
     def launch_manager_menu(self) -> None:
         """Open the project manager menu inside the TUI."""


### PR DESCRIPTION
## Summary
- refine FloTUI layout with Projects/Hive categories
- add `projects_menu` and `hive_menu` dialogs
- allow monitoring sessions from the TUI
- document changes in brain.md

## Testing
- `python3 -m py_compile run_flo.py`
- `python3 run_flo.py --help`

------
https://chatgpt.com/codex/tasks/task_e_688643d7ac8c832eaf8382d1474eda8f