### PR TITLE
Improve Flo TUI with help dialog and spinner

### DIFF
--- a/brain.md
+++ b/brain.md
@@ -49,3 +49,4 @@
 - Each action triggers create/list/monitor or spawn/status/sessions.
 - Updated brain.md with new section.
 \n### 2025-07-27 Final tweaks\n- Added "About" option to main menu with info dialog.\n- Updated handle_choice and new show_about method.\n
+\n### 2025-07-27 Help and spinner\n- Added F1 help dialog and F10 exit shortcut in FloTUI.\n- Implemented spinner in _run_task to show activity.\n- Header now mentions F1 help.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -1,0 +1,3 @@
+## 2025-07-27 – run_flo.py
+F1-Hilfe und Spinner für Hintergrundaufgaben implementiert. Header aktualisiert.
+


### PR DESCRIPTION
## Summary
- add F1 help shortcut and F10 quit
- show progress spinner while background tasks run
- document the update in `brain.md`
- start new project changelog

## Testing
- `python -m py_compile run_flo.py menu.py claude_flow_cli.py openrouter_client.py project_manager.py setup_manager.py parser_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_688647bf4228832e8961990e96aa1633