### PR TITLE
Fix run_flo startup by documenting prompt_toolkit

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -1,3 +1,6 @@
+### 2025-07-27 Dependency fix
+- Added requirements.txt to document prompt_toolkit dependency after start failure.
+
 ### 2025-07-27 TUI additions
 - ProjectManagerTUI kann jetzt Tokens konfigurieren und Quick Commands verwalten.
 

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -1,3 +1,6 @@
+## 2025-07-27 – requirements.txt
+Prompt_toolkit als TUI-Abhängigkeit dokumentiert.
+
 ## 2025-07-27 – run_flo.py
 Quick-Command-Verwaltung und Token-Konfiguration in ProjectManagerTUI integriert.
 ## 2025-07-27 – run_flo.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+prompt_toolkit>=3.0.0
+requests>=2.0


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing prompt_toolkit and requests
- note dependency update in brain log
- document change in changelog

## Testing
- `python -m py_compile run_flo.py`
- `python -m py_compile claude_flow_cli.py openrouter_client.py parser_builder.py project_manager.py setup_manager.py menu.py`
- `python run_flo.py --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_688651128918832ebcedd397a2b520d6