### PR TITLE
Add runtime dependency installer

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -1,3 +1,6 @@
+### 2025-07-27 Auto dependency install
+- New ensure_package helper installs missing packages at runtime.
+
 ### 2025-07-27 Dependency fix
 - Added requirements.txt to document prompt_toolkit dependency after start failure.
 

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -1,3 +1,6 @@
+## 2025-07-27 – run_flo.py
+Automatische Nachinstallation fehlender Pakete via ensure_package.
+
 ## 2025-07-27 – requirements.txt
 Prompt_toolkit als TUI-Abhängigkeit dokumentiert.
 

--- a/run_flo.py
+++ b/run_flo.py
@@ -13,6 +13,24 @@ import threading
 import itertools
 import time
 import os
+
+import subprocess
+
+
+def ensure_package(pkg_name: str) -> None:
+    """Import ``pkg_name`` and install via pip if missing."""
+    try:
+        __import__(pkg_name)
+    except ModuleNotFoundError:
+        print(f"\U0001F4E6 Package '{pkg_name}' not found. Installing…")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg_name])
+        print(f"\u2714 Installed '{pkg_name}'")
+        globals()[pkg_name] = __import__(pkg_name)
+
+
+# Fallback for prompt_toolkit in minimal environments
+ensure_package("prompt_toolkit")
+
 from contextlib import redirect_stdout
 from pathlib import Path
 from typing import List, Optional


### PR DESCRIPTION
## Summary
- ensure prompt_toolkit is installed when starting `run_flo.py`
- document the change in changelog and brain notes

## Testing
- `python3 run_flo.py --help | head -n 20`
- `python3 -m py_compile run_flo.py`

------
https://chatgpt.com/codex/tasks/task_e_6886549fef9c832e8a231d5ee6737678