### PR TITLE
Enhance FloTUI scrolling

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -2,6 +2,9 @@
 - Extended SetupManager to log to flow_autogen.log.
 - Added checks for claude-flow version, screen command, and missing .env.
 - Each step now uses _log helper for unified output.
+### 2025-07-29 TUI scroll fix
+- _run_task now moves cursor to the end after inserting text so new log output
+  is immediately visible in the FloTUI window.
 ### 2025-07-27 Auto dependency install
 - New ensure_package helper installs missing packages at runtime.
 

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -1,6 +1,10 @@
 ## 2025-07-28 – setup_manager.py
 Logging erweitert und Abhängigkeitsprüfung aktualisiert (screen, claude-flow Version). .env-Warnung und Default-Ausgabe.
 
+## 2025-07-29 – run_flo.py
+Anzeige in der FloTUI scrollt nun automatisch ans Ende, sodass neu erzeugte
+Ausgaben sofort sichtbar sind.
+
 ## 2025-07-27 – run_flo.py
 Automatische Nachinstallation fehlender Pakete via ensure_package.
 

--- a/run_flo.py
+++ b/run_flo.py
@@ -254,6 +254,8 @@ class FloTUI:
             text = buf.getvalue()
             def update() -> None:
                 self.output.buffer.insert_text(text)
+                # Scroll to bottom so the newest output is visible
+                self.output.buffer.cursor_position = len(self.output.buffer.text)
             self.app.call_from_executor(update)
             stop.set()
 


### PR DESCRIPTION
## Summary
- improve TUI output scrolling to keep latest text in view
- document TUI enhancement in `brain.md`
- record change in `changelog.md`

## Testing
- `python3 run_flo.py --help`
- `python3 run_flo.py & sleep 5; pkill -f run_flo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866cde1110832ea92ecbd43be07244