### PR TITLE
Enhance FloTUI main menu

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -5,6 +5,12 @@
 ### 2025-07-29 TUI scroll fix
 - _run_task now moves cursor to the end after inserting text so new log output
   is immediately visible in the FloTUI window.
+### 2025-07-30 FloTUI menu update
+- Added MonitoringDashboard and token setup as dedicated options in the main
+  menu.
+- Implemented `configure_tokens` and `show_monitoring` methods in run_flo.py.
+- Main menu now lists Projects, Hive, Monitoring, Token Setup, Advanced, About
+  and Exit.
 ### 2025-07-27 Auto dependency install
 - New ensure_package helper installs missing packages at runtime.
 

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -1,3 +1,7 @@
+## 2025-07-30 – run_flo.py
+Hauptmenü um Monitoring und Token Setup erweitert. Neue Methoden `configure_tokens`
+und `show_monitoring` implementiert. Menü zeigt jetzt sieben Optionen.
+
 ## 2025-07-28 – setup_manager.py
 Logging erweitert und Abhängigkeitsprüfung aktualisiert (screen, claude-flow Version). .env-Warnung und Default-Ausgabe.
 

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -54,12 +54,12 @@
 - [ ] Erweiterbare Menüstruktur mit dynamischer Feature-Erkennung
 
 ## 08 – FloTUI (Text User Interface)
-- [ ] Start über `run_flo.py` ohne Parameter
-- [ ] Layout: Header, Menüleiste, Ausgabefeld, Statuszeile
-- [ ] Tastaturbindung: ESC/F10 (Exit), F1 (Hilfe)
-- [ ] Module:
-  - Projects, Hive, Advanced, Token Setup, About
-- [ ] `ProjectManagerTUI` erweitert CLI-Funktionen grafisch
+- [x] Start über `run_flo.py` ohne Parameter
+- [x] Layout: Header, Menüleiste, Ausgabefeld, Statuszeile
+- [x] Tastaturbindung: ESC/F10 (Exit), F1 (Hilfe)
+- [x] Module:
+  - Projects, Hive, Monitoring, Token Setup, Advanced, About
+- [x] `ProjectManagerTUI` erweitert CLI-Funktionen grafisch
 
 ## 09 – Self-Healing & Monitoring
 - [ ] `monitor_and_self_heal`:


### PR DESCRIPTION
## Summary
- extend FloTUI menu with Monitoring and Token Setup
- add `configure_tokens` and `show_monitoring` helpers
- document new features in brain and changelog
- mark milestone 08 as complete

## Testing
- `python3 run_flo.py --help`
- `python3 run_flo.py & sleep 5; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_688671fa20c0832eba8363f9753c9c7e